### PR TITLE
Move Tests to autoload-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* Moved the `Tests` namespace into a development-only autoloader, to prevent them from potentially being included in projects using this library ([#7]).
+
+## [1.0.0] - 2017-10-24
+
+* Initial release of the PHPUnit Markup Assertions Composer package.
+
+
+[Unreleased]: https://github.com/stevegrunwell/phpunit-markup-assertions/compare/master...develop
+[1.0.0]: https://github.com/stevegrunwell/phpunit-markup-assertions/releases/tag/v1.0.0
+[#7]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/7

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
     },
     "autoload": {
         "psr-4": {
-            "SteveGrunwell\\PHPUnit_Markup_Assertions\\": "src/",
+            "SteveGrunwell\\PHPUnit_Markup_Assertions\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tests\\": "tests/"
         }
     }


### PR DESCRIPTION
Move tests out of the default autoloader and into autoload-dev. Fixes #7.