### PR TITLE
New assertions for elements' innerHTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Added the `assertElementContains()`, `assertElementNotContains()`, `assertElementRegExp()`, and `assertElementNotRegExp()` assertions, for verifying the contents of elements that match the given DOM query ([#6]).
 * Moved the `Tests` namespace into a development-only autoloader, to prevent them from potentially being included in projects using this library ([#7]).
 * [Based on this article by Martin Hujer](https://blog.martinhujer.cz/17-tips-for-using-composer-efficiently/#tip-%236%3A-put-%60composer.lock%60-into-%60.gitignore%60-in-libraries), remove the `composer.lock` file from the library ([#8]).
 * _Lower_ the minimum version of [zendframework/zend-dom](https://packagist.org/packages/zendframework/zend-dom) to 2.2.5 for maximum portability ([#9]).
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/stevegrunwell/phpunit-markup-assertions/compare/master...develop
 [1.0.0]: https://github.com/stevegrunwell/phpunit-markup-assertions/releases/tag/v1.0.0
+[#6]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/6
 [#7]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/7
 [#8]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/8
 [#9]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/9

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ These are the assertions made available to PHPUnit via the `MarkupAssertionsTrai
 * [`assertHasElementWithAttributes()`](#asserthaselementwithattributes)
 * [`assertNotHasElementWithAttributes()`](#assertnothaselementwithattributes)
 
+* [`assertElementContains()`](#assertelementcontains)
+* [`assertElementNotContains()`](#assertelementnotcontains)
+* [`assertElementRegExp()`](#assertelementregexp)
+* [`assertElementNotRegExp()`](#assertelementnotregexp)
+
 ### assertContainsSelector()
 
 Assert that the given string contains an element matching the given selector.
@@ -276,7 +281,7 @@ This method works just like [`assertElementContains()`](#assertelementcontains),
 
 Assert that the element with the given selector does not contain a string.
 
-This method is the inverse of [`assertElementRegExp()`](#assertelementregexp) and behaves like [`assertElementNotContains`](#assertelementnotcontains) except with regular expressions instead of simple string matching.
+This method is the inverse of [`assertElementRegExp()`](#assertelementregexp) and behaves like [`assertElementNotContains()`](#assertelementnotcontains) except with regular expressions instead of simple string matching.
 
 <dl>
     <dt>(string) $regexp</dt>

--- a/README.md
+++ b/README.md
@@ -205,3 +205,86 @@ Assert that an element with the given attributes does not exist in the given mar
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
+
+### assertElementContains()
+
+Assert that the element with the given selector contains a string.
+
+<dl>
+    <dt>(string) $contents</dt>
+    <dd>The string to look for within the DOM node's contents.</dd>
+    <dt>(string) $selector</dt>
+    <dd>A query selector for the element to find.</dd>
+    <dt>(string) $output</dt>
+    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $message</dt>
+    <dd>A message to display if the assertion fails.</dd>
+</dl>
+
+#### Example
+
+```php
+public function testColumnShowsUserEmail()
+{
+    $user = getUser();
+    $table = getTableMarkup();
+
+    $this->assertElementContains(
+        $user->email,
+        'td.email',
+        $table,
+        'The <td class="email"> should contain the user\'s email address.'
+    );
+}
+```
+
+### assertElementNotContains()
+
+Assert that the element with the given selector does not contain a string.
+
+This method is the inverse of [`assertElementContains()`](#assertelementcontains).
+
+<dl>
+    <dt>(string) $contents</dt>
+    <dd>The string to look for within the DOM node's contents.</dd>
+    <dt>(string) $selector</dt>
+    <dd>A query selector for the element to find.</dd>
+    <dt>(string) $output</dt>
+    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $message</dt>
+    <dd>A message to display if the assertion fails.</dd>
+</dl>
+
+### assertElementRegExp()
+
+Assert that the element with the given selector contains a string.
+
+This method works just like [`assertElementContains()`](#assertelementcontains), but uses regular expressions instead of simple string matching.
+
+<dl>
+    <dt>(string) $regexp</dt>
+    <dd>The regular expression pattern to look for within the DOM node.</dd>
+    <dt>(string) $selector</dt>
+    <dd>A query selector for the element to find.</dd>
+    <dt>(string) $output</dt>
+    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $message</dt>
+    <dd>A message to display if the assertion fails.</dd>
+</dl>
+
+### assertElementNotRegExp()
+
+Assert that the element with the given selector does not contain a string.
+
+This method is the inverse of [`assertElementRegExp()`](#assertelementregexp) and behaves like [`assertElementNotContains`](#assertelementnotcontains) except with regular expressions instead of simple string matching.
+
+<dl>
+    <dt>(string) $regexp</dt>
+    <dd>The regular expression pattern to look for within the DOM node.</dd>
+    <dt>(string) $selector</dt>
+    <dd>A query selector for the element to find.</dd>
+    <dt>(string) $output</dt>
+    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $message</dt>
+    <dd>A message to display if the assertion fails.</dd>
+</dl>

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -127,6 +127,40 @@ trait MarkupAssertionsTrait
     }
 
     /**
+     * Assert an element's contents contain the given regular expression pattern.
+     *
+     * @param string $regexp   The regular expression pattern to look for within the DOM node.
+     * @param string $selector A query selector for the element to find.
+     * @param string $output   The output that should contain the $selector.
+     * @param string $message  A message to display if the assertion fails.
+     */
+    public function assertElementRegExp($regexp, $selector = '', $output = '', $message = '')
+    {
+        $this->assertRegExp(
+            $regexp,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
+    }
+
+    /**
+     * Assert an element's contents do not contain the given regular expression pattern.
+     *
+     * @param string $regexp   The regular expression pattern to look for within the DOM node.
+     * @param string $selector A query selector for the element to find.
+     * @param string $output   The output that should not contain the $selector.
+     * @param string $message  A message to display if the assertion fails.
+     */
+    public function assertElementNotRegExp($regexp, $selector = '', $output = '', $message = '')
+    {
+        $this->assertNotRegExp(
+            $regexp,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
+    }
+
+    /**
      * Build a new DOMDocument from the given markup, then execute a query against it.
      *
      * @param string $markup The HTML for the DOMDocument.

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -8,6 +8,7 @@
 
 namespace SteveGrunwell\PHPUnit_Markup_Assertions;
 
+use DOMDocument;
 use PHPUnit\Framework\RiskyTestError;
 use Zend\Dom\Query;
 
@@ -92,6 +93,40 @@ trait MarkupAssertionsTrait
     }
 
     /**
+     * Assert an element's contents contain the given string.
+     *
+     * @param string $contents The string to look for within the DOM node's contents.
+     * @param string $selector A query selector for the element to find.
+     * @param string $output   The output that should contain the $selector.
+     * @param string $message  A message to display if the assertion fails.
+     */
+    public function assertElementContains($contents, $selector = '', $output = '', $message = '')
+    {
+        $this->assertContains(
+            $contents,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
+    }
+
+    /**
+     * Assert an element's contents do not contain the given string.
+     *
+     * @param string $contents The string to look for within the DOM node's contents.
+     * @param string $selector A query selector for the element to find.
+     * @param string $output   The output that should not contain the $selector.
+     * @param string $message  A message to display if the assertion fails.
+     */
+    public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
+    {
+        $this->assertNotContains(
+            $contents,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
+    }
+
+    /**
      * Build a new DOMDocument from the given markup, then execute a query against it.
      *
      * @param string $markup The HTML for the DOMDocument.
@@ -131,5 +166,29 @@ trait MarkupAssertionsTrait
         });
 
         return implode('', $attributes);
+    }
+
+    /**
+     * Given HTML markup and a DOM selector query, collect the innerHTML of the matched selectors.
+     *
+     * @param string $markup The HTML for the DOMDocument.
+     * @param string $query  The DOM selector query.
+     *
+     * @return string The concatenated innerHTML of any matched selectors.
+     */
+    protected function getInnerHtmlOfMatchedElements($markup, $query)
+    {
+        $results  = $this->executeDomQuery($markup, $query);
+        $contents = [];
+
+        // Loop through results and collect their innerHTML values.
+        foreach ($results as $result) {
+            $document = new DOMDocument;
+            $document->appendChild($document->importNode($result->firstChild, true));
+
+            $contents[] = trim($document->saveHTML());
+        }
+
+        return implode(PHP_EOL, $contents);
     }
 }

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\RiskyTestError;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -82,6 +83,37 @@ class MarkupAssertionsTraitTest extends TestCase
         );
     }
 
+    public function testAssertElementContains()
+    {
+        $this->testcase->assertElementContains(
+            'ipsum',
+            '#main',
+            '<header>Lorem ipsum</header><div id="main">Lorem ipsum</div>'
+        );
+    }
+
+    public function testAssertElementContainsScopesToSelector()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The #main div does not contain the string "ipsum".');
+
+        $this->testcase->assertElementContains(
+            'ipsum',
+            '#main',
+            '<header>Lorem ipsum</header><div id="main">Foo bar baz</div>',
+            'The #main div does not contain the string "ipsum".'
+        );
+    }
+
+    public function testAssertElementNotContains()
+    {
+        $this->testcase->assertElementNotContains(
+            'ipsum',
+            '#main',
+            '<header>Foo bar baz</header><div id="main">Some string</div>'
+        );
+    }
+
     /**
      * @dataProvider attributeProvider()
      */
@@ -102,6 +134,16 @@ class MarkupAssertionsTraitTest extends TestCase
         $method->setAccessible(true);
 
         $method->invoke($this->testcase, []);
+    }
+
+    /**
+     * @dataProvider innerHtmlProvider().
+     */
+    public function testGetInnerHtmlOfMatchedElements($markup, $selector, $expected) {
+        $method = new ReflectionMethod($this->testcase, 'getInnerHtmlOfMatchedElements');
+        $method->setAccessible(true);
+
+        $this->assertEquals($expected, $method->invoke($this->testcase, $markup, $selector));
     }
 
     /**
@@ -140,6 +182,30 @@ class MarkupAssertionsTraitTest extends TestCase
                     'name' => 'Austin "Danger" Powers',
                 ],
                 '[name="Austin &quot;Danger&quot; Powers"]',
+            ],
+        ];
+    }
+
+    /**
+     * Data provider for testGetInnerHtmlOfMatchedElements().
+     */
+    public function innerHtmlProvider()
+    {
+        return [
+            'A single match' => [
+                '<body>Foo bar baz</body>',
+                'body',
+                'Foo bar baz',
+            ],
+            'Multiple matching elements' => [
+                '<ul><li>Foo</li><li>Bar</li><li>Baz</li>',
+                'li',
+                'Foo' . PHP_EOL . 'Bar' . PHP_EOL . 'Baz',
+            ],
+            'Nested elements' => [
+                '<h1><a href="https://example.com">Example site</a></h1>',
+                'h1',
+                '<a href="https://example.com">Example site</a>',
             ],
         ];
     }

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -114,6 +114,33 @@ class MarkupAssertionsTraitTest extends TestCase
         );
     }
 
+    public function testAssertElementRegExp()
+    {
+        $this->testcase->assertElementRegExp(
+            '/[A-Z0-9-]+/',
+            '#main',
+            '<header>Lorem ipsum</header><div id="main">ABC123</div>'
+        );
+    }
+
+    public function testAssertElementRegExpWithNestedElements()
+    {
+        $this->testcase->assertElementRegExp(
+            '/[A-Z]+/',
+            '#main',
+            '<header>Lorem ipsum</header><div id="main"><span>ABC</span></div>'
+        );
+    }
+
+    public function testAssertElementNotRegExp()
+    {
+        $this->testcase->assertElementNotRegExp(
+            '/[0-9-]+/',
+            '#main',
+            '<header>Foo bar baz</header><div id="main">ABC</div>'
+        );
+    }
+
     /**
      * @dataProvider attributeProvider()
      */


### PR DESCRIPTION
This PR introduces four new assertions:

1. assertElementContains()
2. assertElementNotContains()
3. assertElementRegExp()
4. assertElementNotRegExp()

The general goal is to be able to assert that an element matching a selector _exists_ and that its inner HTML matches either a string or regular expression. Fixes #6.