### PR TITLE
Support spaces in attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* Bumped the minimum version of zendframework/zend-dom to 2.7, which includes a fix for attribute values that include spaces ([#13]).
+
 ## [1.1.0] - 2018-01-14
 
 * Added the `assertElementContains()`, `assertElementNotContains()`, `assertElementRegExp()`, and `assertElementNotRegExp()` assertions, for verifying the contents of elements that match the given DOM query ([#6]).
@@ -23,3 +27,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#7]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/7
 [#8]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/8
 [#9]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/9
+[#13]: https://github.com/stevegrunwell/phpunit-markup-assertions/issues/13

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/stevegrunwell/phpunit-markup-assertions/"
     },
     "require": {
-        "zendframework/zend-dom": "^2.2.5"
+        "zendframework/zend-dom": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": ">=6.0"

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -72,6 +72,19 @@ class MarkupAssertionsTraitTest extends TestCase
         );
     }
 
+    /**
+     * @link https://github.com/stevegrunwell/phpunit-markup-assertions/issues/13
+     */
+    public function testAssertHasElementWithAttributesWithSpacesInTheAttributeValue()
+    {
+        $this->testcase->assertHasElementWithAttributes(
+            [
+                'data-attr' => 'foo bar baz',
+            ],
+            '<div data-attr="foo bar baz">Contents</div>'
+        );
+    }
+
     public function testAssertNotHasElementWithAttributes()
     {
         $this->testcase->assertNotHasElementWithAttributes(

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -105,6 +105,15 @@ class MarkupAssertionsTraitTest extends TestCase
         );
     }
 
+    public function testAssertElementContainsMultipleSelectors()
+    {
+        $this->testcase->assertElementContains(
+            'ipsum',
+            '#main .foo',
+            '<div id="main"><span class="foo">Lorem ipsum</span></div>'
+        );
+    }
+
     public function testAssertElementContainsScopesToSelector()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This PR bumps the minimum version of zendframework/zend-dom to 2.7, which includes the necessary upstream fix for #13.

Fixes #13.