### PR TITLE
Fix PHPUnit warning with using assertContains on strings

### DIFF
--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -141,7 +141,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
     {
-        if (method_exists($this, 'assertStringContainsString')) {
+        if (method_exists($this, 'assertStringNotContainsString')) {
             $this->assertStringNotContainsString(
                 $contents,
                 $this->getInnerHtmlOfMatchedElements($output, $selector),

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -114,7 +114,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementContains($contents, $selector = '', $output = '', $message = '')
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             $contents,
             $this->getInnerHtmlOfMatchedElements($output, $selector),
             $message
@@ -133,7 +133,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
     {
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             $contents,
             $this->getInnerHtmlOfMatchedElements($output, $selector),
             $message

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -114,11 +114,19 @@ trait MarkupAssertionsTrait
      */
     public function assertElementContains($contents, $selector = '', $output = '', $message = '')
     {
-        $this->assertStringContainsString(
-            $contents,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
-            $message
-        );
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString(
+                $contents,
+                $this->getInnerHtmlOfMatchedElements($output, $selector),
+                $message
+            );
+        } else {
+            $this->assertContains(
+                $contents,
+                $this->getInnerHtmlOfMatchedElements($output, $selector),
+                $message
+            );
+        }
     }
 
     /**
@@ -133,11 +141,20 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
     {
-        $this->assertStringNotContainsString(
-            $contents,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
-            $message
-        );
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringNotContainsString(
+                $contents,
+                $this->getInnerHtmlOfMatchedElements($output, $selector),
+                $message
+            );
+        }
+        else {
+            $this->assertNotContains(
+                $contents,
+                $this->getInnerHtmlOfMatchedElements($output, $selector),
+                $message
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
When using the assertElementContains and assertElementNotContains assertions in PHPUnit 8.5, a warning is thrown in the testcase:
```
PHPUnit 8.5.3 by Sebastian Bergmann and contributors.

W                                                                   1 / 1 (100%)

Time: 4.88 seconds, Memory: 26.00 MB

There was 1 warning:

1) Tests\Unit\HTML::itIsAwesome
Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
Using assertNotContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringNotContainsString() or assertStringNotContainsStringIgnoringCase() instead.

WARNINGS!
Tests: 1, Assertions: 2, Warnings: 1.
```

This pull request fixes this warning by using the new assertStringContainsString and assertStringNotContainsString. 

I have two issues with this PR myself:
- the method_exists call is needed to keep compatibility with PHPUnit 7 and earlier. Is this needed?
- I haven't added to the testcases, because I don't know how to check for a console warning.