### PR TITLE
PHP 8.0 compatibility

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,6 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        if: ${{ matrix.php != '7.4' }}
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
@@ -37,5 +36,4 @@ jobs:
         run: composer install --no-interaction --prefer-dist --no-suggest --no-progress
 
       - name: Run test suite
-        if: ${{ matrix.php != '7.4' }}
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "source": "https://github.com/stevegrunwell/phpunit-markup-assertions/"
     },
     "require": {
-        "laminas/laminas-dom": "^2.7.0|^2.8"
+        "php": "^5.6 || ^7.0 || ^8.0",
+        "laminas/laminas-dom": "~2.7.2 || ^2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.2"
@@ -44,9 +45,6 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true,
-        "platform": {
-            "php": "7.4"
-        }
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/stevegrunwell/phpunit-markup-assertions/"
     },
     "require": {
-        "laminas/laminas-dom": "^2.7"
+        "laminas/laminas-dom": "^2.7.0|^2.8"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.2"


### PR DESCRIPTION
[Now that laminas/laminas-dom has added PHP 8.0 support](https://github.com/laminas/laminas-dom/releases/tag/2.8.0), we can update this library to take advantage.

It's worth noting that 2.8.0 dropped PHP < 7.3, so we need to take care to ensure test suites running older versions of PHP can still load 2.7.x.

Fixes #23.