### PR TITLE
Update regular expression methods

### DIFF
--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -169,7 +169,11 @@ trait MarkupAssertionsTrait
      */
     public function assertElementRegExp($regexp, $selector = '', $output = '', $message = '')
     {
-        $this->assertRegExp(
+        $method = method_exists($this, 'assertMatchesRegularExpression')
+            ? 'assertMatchesRegularExpression'
+            : 'assertRegExp';
+
+        $this->$method(
             $regexp,
             $this->getInnerHtmlOfMatchedElements($output, $selector),
             $message
@@ -188,7 +192,11 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotRegExp($regexp, $selector = '', $output = '', $message = '')
     {
-        $this->assertNotRegExp(
+        $method = method_exists($this, 'assertDoesNotMatchRegularExpression')
+            ? 'assertDoesNotMatchRegularExpression'
+            : 'assertNotRegExp';
+
+        $this->$method(
             $regexp,
             $this->getInnerHtmlOfMatchedElements($output, $selector),
             $message


### PR DESCRIPTION
When running `$this->assert[Not]RegExp()` on the latest versions of PHPUnit, we get the following warning:

> assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.

This PR updates `assertElementRegExp()` and `assertElementNotRegExp()` to check for the newer method and use it if it's available.