### PR TITLE
Refactor assertElementContains to match assertElementRegExp

### DIFF
--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -114,19 +114,15 @@ trait MarkupAssertionsTrait
      */
     public function assertElementContains($contents, $selector = '', $output = '', $message = '')
     {
-        if (method_exists($this, 'assertStringContainsString')) {
-            $this->assertStringContainsString(
-                $contents,
-                $this->getInnerHtmlOfMatchedElements($output, $selector),
-                $message
-            );
-        } else {
-            $this->assertContains(
-                $contents,
-                $this->getInnerHtmlOfMatchedElements($output, $selector),
-                $message
-            );
-        }
+        $method = method_exists($this, 'assertStringContainsString')
+            ? 'assertStringContainsString'
+            : 'assertContains';
+
+        $this->$method(
+            $contents,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
     }
 
     /**
@@ -141,20 +137,15 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
     {
-        if (method_exists($this, 'assertStringNotContainsString')) {
-            $this->assertStringNotContainsString(
-                $contents,
-                $this->getInnerHtmlOfMatchedElements($output, $selector),
-                $message
-            );
-        }
-        else {
-            $this->assertNotContains(
-                $contents,
-                $this->getInnerHtmlOfMatchedElements($output, $selector),
-                $message
-            );
-        }
+        $method = method_exists($this, 'assertStringNotContainsString')
+            ? 'assertStringNotContainsString'
+            : 'assertNotContains';
+
+        $this->$method(
+            $contents,
+            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $message
+        );
     }
 
     /**


### PR DESCRIPTION
Two PRs, #20 and #27, refactored the `assertElementContains()` and `assertElementRegExp()` methods, respectively, to avoid warnings about deprecated PHPUnit methods.

This PR updates the changes made in #20 to match those made in #27 for consistency, using a `$method` variable instead of an if/else statement with two separate method calls.