### PR TITLE
Only run GitHub Actions on pull_request, not push

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run:


### PR DESCRIPTION
We don't need to run it twice, that's just wasted cycles.