### PR TITLE
Update $output to $markup, improve inline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This library introduces the `MarkupAssertionsTrait` trait for use in [PHPUnit](https://phpunit.de) tests.
 
-These assertions enable you to inspect generated markup without having to muddy tests with [`DOMDocument`](http://php.net/manual/en/class.domdocument.php) or nasty regular expressions. If you're generating markup at all with PHP, the PHPUnit Markup Assertions trait aims to make the output testable.
+These assertions enable you to inspect generated markup without having to muddy tests with [`DOMDocument`](http://php.net/manual/en/class.domdocument.php) or nasty regular expressions. If you're generating markup at all with PHP, the PHPUnit Markup Assertions trait aims to make the output testable without making your tests fragile.
 
 ## Example
 
@@ -22,10 +22,10 @@ class MyUnitTest extends TestCase
      */
     public function testRenderFormContainsInputs()
     {
-        $output = render_form();
+        $markup = render_form();
 
-        $this->assertContainsSelector('#first-name', $output);
-        $this->assertContainsSelector('#last-name', $output);
+        $this->assertContainsSelector('#first-name', $markup);
+        $this->assertContainsSelector('#last-name', $markup);
     }
 }
 ```
@@ -104,8 +104,8 @@ Assert that the given string contains an element matching the given selector.
 <dl>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -130,8 +130,8 @@ This method is the inverse of [`assertContainsSelector()`](#assertcontainsselect
 <dl>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should not contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should not contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -145,7 +145,7 @@ Assert the number of times an element matching the given selector is found.
     <dd>The number of matching elements expected.</dd>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
+    <dt>(string) $markup</dt>
     <dd>The markup to run the assertion against.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
@@ -171,8 +171,8 @@ Assert that an element with the given attributes exists in the given markup.
 <dl>
     <dt>(array) $attributes</dt>
     <dd>An array of HTML attributes that should be found on the element.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain an element with the provided <code>$attributes</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain an element with the provided <code>$attributes</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -203,8 +203,8 @@ Assert that an element with the given attributes does not exist in the given mar
 <dl>
     <dt>(array) $attributes</dt>
     <dd>An array of HTML attributes that should not be found on the element.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should not contain an element with the provided <code>$attributes</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should not contain an element with the provided <code>$attributes</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -218,8 +218,8 @@ Assert that the element with the given selector contains a string.
     <dd>The string to look for within the DOM node's contents.</dd>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -252,8 +252,8 @@ This method is the inverse of [`assertElementContains()`](#assertelementcontains
     <dd>The string to look for within the DOM node's contents.</dd>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -269,8 +269,8 @@ This method works just like [`assertElementContains()`](#assertelementcontains),
     <dd>The regular expression pattern to look for within the DOM node.</dd>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>
@@ -286,8 +286,8 @@ This method is the inverse of [`assertElementRegExp()`](#assertelementregexp) an
     <dd>The regular expression pattern to look for within the DOM node.</dd>
     <dt>(string) $selector</dt>
     <dd>A query selector for the element to find.</dd>
-    <dt>(string) $output</dt>
-    <dd>The output that should contain the <code>$selector</code>.</dd>
+    <dt>(string) $markup</dt>
+    <dd>The markup that should contain the <code>$selector</code>.</dd>
     <dt>(string) $message</dt>
     <dd>A message to display if the assertion fails.</dd>
 </dl>

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -21,14 +21,14 @@ trait MarkupAssertionsTrait
      * @since 1.0.0
      *
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should contain the $selector.
+     * @param string $markup   The output that should contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertContainsSelector($selector, $output = '', $message = '')
+    public function assertContainsSelector($selector, $markup = '', $message = '')
     {
-        $results = $this->executeDomQuery($output, $selector);
+        $results = $this->executeDomQuery($markup, $selector);
 
         $this->assertGreaterThan(0, count($results), $message);
     }
@@ -39,12 +39,12 @@ trait MarkupAssertionsTrait
      * @since 1.0.0
      *
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should not contain the $selector.
+     * @param string $markup   The output that should not contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      */
-    public function assertNotContainsSelector($selector, $output = '', $message = '')
+    public function assertNotContainsSelector($selector, $markup = '', $message = '')
     {
-        $results = $this->executeDomQuery($output, $selector);
+        $results = $this->executeDomQuery($markup, $selector);
 
         $this->assertEquals(0, count($results), $message);
     }
@@ -56,14 +56,14 @@ trait MarkupAssertionsTrait
      *
      * @param int    $count    The number of matching elements expected.
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The markup to run the assertion against.
+     * @param string $markup   The markup to run the assertion against.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertSelectorCount($count, $selector, $output = '', $message = '')
+    public function assertSelectorCount($count, $selector, $markup = '', $message = '')
     {
-        $results = $this->executeDomQuery($output, $selector);
+        $results = $this->executeDomQuery($markup, $selector);
 
         $this->assertCount($count, $results, $message);
     }
@@ -74,17 +74,17 @@ trait MarkupAssertionsTrait
      * @since 1.0.0
      *
      * @param array  $attributes An array of HTML attributes that should be found on the element.
-     * @param string $output     The output that should contain an element with the
+     * @param string $markup     The output that should contain an element with the
      *                           provided $attributes.
      * @param string $message    A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertHasElementWithAttributes($attributes = [], $output = '', $message = '')
+    public function assertHasElementWithAttributes($attributes = [], $markup = '', $message = '')
     {
         $this->assertContainsSelector(
             '*' . $this->flattenAttributeArray($attributes),
-            $output,
+            $markup,
             $message
         );
     }
@@ -95,17 +95,17 @@ trait MarkupAssertionsTrait
      * @since 1.0.0
      *
      * @param array  $attributes An array of HTML attributes that should be found on the element.
-     * @param string $output     The output that should not contain an element with the
+     * @param string $markup     The output that should not contain an element with the
      *                           provided $attributes.
      * @param string $message    A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertNotHasElementWithAttributes($attributes = [], $output = '', $message = '')
+    public function assertNotHasElementWithAttributes($attributes = [], $markup = '', $message = '')
     {
         $this->assertNotContainsSelector(
             '*' . $this->flattenAttributeArray($attributes),
-            $output,
+            $markup,
             $message
         );
     }
@@ -117,12 +117,12 @@ trait MarkupAssertionsTrait
      *
      * @param string $contents The string to look for within the DOM node's contents.
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should contain the $selector.
+     * @param string $markup   The output that should contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertElementContains($contents, $selector = '', $output = '', $message = '')
+    public function assertElementContains($contents, $selector = '', $markup = '', $message = '')
     {
         $method = method_exists($this, 'assertStringContainsString')
             ? 'assertStringContainsString'
@@ -130,7 +130,7 @@ trait MarkupAssertionsTrait
 
         $this->$method(
             $contents,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
         );
     }
@@ -142,12 +142,12 @@ trait MarkupAssertionsTrait
      *
      * @param string $contents The string to look for within the DOM node's contents.
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should not contain the $selector.
+     * @param string $markup   The output that should not contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertElementNotContains($contents, $selector = '', $output = '', $message = '')
+    public function assertElementNotContains($contents, $selector = '', $markup = '', $message = '')
     {
         $method = method_exists($this, 'assertStringNotContainsString')
             ? 'assertStringNotContainsString'
@@ -155,7 +155,7 @@ trait MarkupAssertionsTrait
 
         $this->$method(
             $contents,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
         );
     }
@@ -167,12 +167,12 @@ trait MarkupAssertionsTrait
      *
      * @param string $regexp   The regular expression pattern to look for within the DOM node.
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should contain the $selector.
+     * @param string $markup   The output that should contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertElementRegExp($regexp, $selector = '', $output = '', $message = '')
+    public function assertElementRegExp($regexp, $selector = '', $markup = '', $message = '')
     {
         $method = method_exists($this, 'assertMatchesRegularExpression')
             ? 'assertMatchesRegularExpression'
@@ -180,7 +180,7 @@ trait MarkupAssertionsTrait
 
         $this->$method(
             $regexp,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
         );
     }
@@ -192,12 +192,12 @@ trait MarkupAssertionsTrait
      *
      * @param string $regexp   The regular expression pattern to look for within the DOM node.
      * @param string $selector A query selector for the element to find.
-     * @param string $output   The output that should not contain the $selector.
+     * @param string $markup   The output that should not contain the $selector.
      * @param string $message  A message to display if the assertion fails.
      *
      * @return void
      */
-    public function assertElementNotRegExp($regexp, $selector = '', $output = '', $message = '')
+    public function assertElementNotRegExp($regexp, $selector = '', $markup = '', $message = '')
     {
         $method = method_exists($this, 'assertDoesNotMatchRegularExpression')
             ? 'assertDoesNotMatchRegularExpression'
@@ -205,7 +205,7 @@ trait MarkupAssertionsTrait
 
         $this->$method(
             $regexp,
-            $this->getInnerHtmlOfMatchedElements($output, $selector),
+            $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
         );
     }

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -287,6 +287,8 @@ class MarkupAssertionsTraitTest extends TestCase
 
     /**
      * Data provider for testGetInnerHtmlOfMatchedElements().
+     *
+     * @return array<string,array<string>>
      */
     public function provideInnerHtml()
     {
@@ -311,6 +313,8 @@ class MarkupAssertionsTraitTest extends TestCase
 
     /**
      * Data provider for testAssertContainsSelector().
+     *
+     * @return array<string,array<string>>
      */
     public function provideSelectorVariants()
     {


### PR DESCRIPTION
This PR replaces the `$output` variable name used throughout the trait with `$markup` to make its purpose more clear.

Additionally, inline documentation has been fleshed out a bit, and the README file updated to match.