### PR TITLE
Switch from laminas/laminas-dom to symfony/dom-crawler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "laminas/laminas-dom": "~2.7.2 || ^2.8"
+        "symfony/css-selector": "^3.4|^4.4|^5.4|^6.0",
+        "symfony/dom-crawler": "^3.4|^4.4|^5.4|^6.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.2 || ^6.2"

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -222,7 +222,7 @@ trait MarkupAssertionsTrait
      *
      * @return Crawler
      */
-    protected function executeDomQuery($markup, $query)
+    private function executeDomQuery($markup, $query)
     {
         $dom = new Crawler($markup);
 
@@ -240,7 +240,7 @@ trait MarkupAssertionsTrait
      *
      * @return string A XPath attribute query selector.
      */
-    protected function flattenAttributeArray(array $attributes)
+    private function flattenAttributeArray(array $attributes)
     {
         if (empty($attributes)) {
             throw new RiskyTestError('Attributes array is empty.');
@@ -268,7 +268,7 @@ trait MarkupAssertionsTrait
      *
      * @return string The concatenated innerHTML of any matched selectors.
      */
-    protected function getInnerHtmlOfMatchedElements($markup, $query)
+    private function getInnerHtmlOfMatchedElements($markup, $query)
     {
         $results  = $this->executeDomQuery($markup, $query);
         $contents = [];

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -73,10 +73,11 @@ trait MarkupAssertionsTrait
      *
      * @since 1.0.0
      *
-     * @param array  $attributes An array of HTML attributes that should be found on the element.
-     * @param string $markup     The output that should contain an element with the
-     *                           provided $attributes.
-     * @param string $message    A message to display if the assertion fails.
+     * @param array<string, scalar> $attributes An array of HTML attributes that should be found
+     *                                          on the element.
+     * @param string                $markup     The output that should contain an element with the
+     *                                          provided $attributes.
+     * @param string                $message    A message to display if the assertion fails.
      *
      * @return void
      */
@@ -94,10 +95,11 @@ trait MarkupAssertionsTrait
      *
      * @since 1.0.0
      *
-     * @param array  $attributes An array of HTML attributes that should be found on the element.
-     * @param string $markup     The output that should not contain an element with the
-     *                           provided $attributes.
-     * @param string $message    A message to display if the assertion fails.
+     * @param array<string, scalar> $attributes An array of HTML attributes that should be found
+     *                                          on the element.
+     * @param string                $markup     The output that should not contain an element with
+     *                                          the provided $attributes.
+     * @param string                $message    A message to display if the assertion fails.
      *
      * @return void
      */
@@ -234,7 +236,7 @@ trait MarkupAssertionsTrait
      *
      * @throws RiskyTestError When the $attributes array is empty.
      *
-     * @param array $attributes HTML attributes and their values.
+     * @param array<string, scalar> $attributes HTML attributes and their values.
      *
      * @return string A XPath attribute query selector.
      */

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -8,10 +8,8 @@
 
 namespace SteveGrunwell\PHPUnit_Markup_Assertions;
 
-use DOMDocument;
-use Laminas\Dom\Document;
-use Laminas\Dom\Document\Query;
 use PHPUnit\Framework\RiskyTestError;
+use Symfony\Component\DomCrawler\Crawler;
 
 trait MarkupAssertionsTrait
 {
@@ -220,15 +218,13 @@ trait MarkupAssertionsTrait
      * @param string $markup The HTML for the DOMDocument.
      * @param string $query  The DOM selector query.
      *
-     * @return \Laminas\Dom\Document\NodeList
+     * @return Crawler
      */
     protected function executeDomQuery($markup, $query)
     {
-        return Query::execute(
-            $query,
-            new Document('<?xml encoding="UTF-8">' . $markup, Document::DOC_HTML, 'UTF-8'),
-            Query::TYPE_CSS
-        );
+        $dom = new Crawler($markup);
+
+        return $dom->filter($query);
     }
 
     /**
@@ -277,7 +273,7 @@ trait MarkupAssertionsTrait
 
         // Loop through results and collect their innerHTML values.
         foreach ($results as $result) {
-            $document = new DOMDocument();
+            $document = new \DOMDocument();
             $document->appendChild($document->importNode($result->firstChild, true));
 
             $contents[] = trim(html_entity_decode($document->saveHTML()));


### PR DESCRIPTION
[The laminas/laminas-dom project is no longer being actively maintained](https://github.com/laminas/laminas-dom), which feels like it could be a pain point as CSS continues to evolve.

To stay on top of this, this PR switches out the underlying CSS => XPath translation to the [symfony/css-selector](https://symfony.com/doc/current/components/css_selector.html) component and the querying to [symfony/dom-crawler](https://symfony.com/doc/current/components/dom_crawler.html).

While the tests are all still passing and nothing changed in the contract of the public methods, I don't like the idea of swapping out the one underlying dependency for another in a minor version release. Thus this PR will serve as the foundation for the next major version of this library.

Fixes #42.