### PR TITLE
Re-enable code coverage reporting to Coveralls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,7 +44,7 @@ This project uses [the PSR-2 coding standards](http://www.php-fig.org/psr/psr-2/
 [PHPUnit](https://phpunit.de/) is included as a development dependency, and should be run regularly. When submitting changes, please be sure to add or update unit tests accordingly. You may run unit tests at any time by running:
 
 ```bash
-$ ./vendor/bin/phpunit
+$ composer test
 ```
 
 #### Code coverage

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,30 @@
+name: Code Coverage
+
+on: [pull_request]
+
+jobs:
+  coverage:
+    name: Report code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run test suite
+        run: vendor/bin/simple-phpunit --coverage-text --coverage-clover=tests/coverage
+
+      - name: Publish to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          files: tests/coverage
+          format: clover
+          fail-on-error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.DS_Store
-tests/coverage
-vendor
 .phpunit.result.cache
 .vscode
+tests/coverage
+vendor
 
 # The composer.lock file is not needed, as this is a library whose dependencies
 # will depend on the version of PHP being used.

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,10 @@
     "scripts": {
         "test": [
             "simple-phpunit --testdox"
-        ],
-        "test-coverage": [
-            "phpdbg -qrr -d memory_limit=-1 ./vendor/bin/simple-phpunit --coverage-html=tests/coverage --colors=always"
         ]
     },
     "scripts-descriptions": {
-        "test": "Run all test suites.",
-        "test-coverage": "Generate code coverage reports in tests/coverage."
+        "test": "Run all test suites."
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,14 @@
     "scripts": {
         "test": [
             "simple-phpunit --testdox"
+        ],
+        "test-coverage": [
+            "XDEBUG_MODE=coverage ./vendor/bin/simple-phpunit --coverage-html=tests/coverage --colors=always"
         ]
     },
     "scripts-descriptions": {
-        "test": "Run all test suites."
+        "test": "Run all test suites.",
+        "test-coverage": "Generate code coverage reports in tests/coverage."
     },
     "config": {
         "preferred-install": "dist",

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -128,7 +128,7 @@ trait MarkupAssertionsTrait
     {
         $method = method_exists($this, 'assertStringContainsString')
             ? 'assertStringContainsString'
-            : 'assertContains';
+            : 'assertContains'; // @codeCoverageIgnore
 
         $this->$method(
             $contents,
@@ -153,7 +153,7 @@ trait MarkupAssertionsTrait
     {
         $method = method_exists($this, 'assertStringNotContainsString')
             ? 'assertStringNotContainsString'
-            : 'assertNotContains';
+            : 'assertNotContains'; // @codeCoverageIgnore
 
         $this->$method(
             $contents,
@@ -178,7 +178,7 @@ trait MarkupAssertionsTrait
     {
         $method = method_exists($this, 'assertMatchesRegularExpression')
             ? 'assertMatchesRegularExpression'
-            : 'assertRegExp';
+            : 'assertRegExp'; // @codeCoverageIgnore
 
         $this->$method(
             $regexp,
@@ -203,7 +203,7 @@ trait MarkupAssertionsTrait
     {
         $method = method_exists($this, 'assertDoesNotMatchRegularExpression')
             ? 'assertDoesNotMatchRegularExpression'
-            : 'assertNotRegExp';
+            : 'assertNotRegExp'; // @codeCoverageIgnore
 
         $this->$method(
             $regexp,


### PR DESCRIPTION
This PR adds a new workflow, code-coverage.yml, which (re-)runs the PHPUnit test suite against one version of PHP (currently 8.2) and publishes the results to [Coveralls](https://coveralls.io/github/stevegrunwell/phpunit-markup-assertions).

This restores the behavior prior to the migration to GitHub Actions (#24) and fixes #25.