### PR TITLE
Enable code coverage to be computed when merging into develop and/or main

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,6 +1,11 @@
 name: Code Coverage
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
 
 jobs:
   coverage:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PHPUnit Markup Assertions
 
 ![Build Status](https://github.com/stevegrunwell/phpunit-markup-assertions/workflows/Unit%20Tests/badge.svg)
-[![GitHub release](https://img.shields.io/github/release/stevegrunwell/phpunit-markup-assertions.svg)](https://github.com/stevegrunwell/phpunit-markup-assertions/releases)
+[![Code Coverage](https://coveralls.io/repos/github/stevegrunwell/phpunit-markup-assertions/badge.svg?branch=develop)](https://coveralls.io/github/stevegrunwell/phpunit-markup-assertions?branch=develop)
+[![GitHub Release](https://img.shields.io/github/release/stevegrunwell/phpunit-markup-assertions.svg)](https://github.com/stevegrunwell/phpunit-markup-assertions/releases)
 
 This library introduces the `MarkupAssertionsTrait` trait for use in [PHPUnit](https://phpunit.de) tests.
 


### PR DESCRIPTION
Additionally, add a code coverage badge to the README file.

Expands on #25.