### PR TITLE
Add PHP_CodeSniffer for checking coding standards

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,23 @@
+name: Coding Standards
+
+on: [pull_request]
+
+jobs:
+  phpcs:
+    name: PHP_CodeSniffer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run test suite
+        run: composer coding-standards

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="Custom ruleset">
+    <description>Coding standards for PHPUnit Markup Assertions</description>
+
+    <!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+    <!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Default to PSR-12 for coding standards-->
+    <rule ref="PSR12"/>
+
+    <!-- The tests/ directory may use snake_case for test methods -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <!-- Ensure we're compatible with PHP 5.6+ -->
+    <rule ref="PHPCompatibility"/>
+    <config name="testVersion" value="5.6-"/>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "symfony/dom-crawler": "^3.4|^4.4|^5.4|^6.0"
     },
     "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "phpcsstandards/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^5.2 || ^6.2"
     },
     "autoload": {
@@ -33,6 +36,9 @@
         }
     },
     "scripts": {
+        "coding-standards": [
+            "phpcs"
+        ],
         "test": [
             "simple-phpunit --testdox"
         ],
@@ -41,12 +47,16 @@
         ]
     },
     "scripts-descriptions": {
+        "coding-standards": "Check coding standards.",
         "test": "Run all test suites.",
         "test-coverage": "Generate code coverage reports in tests/coverage."
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "archive": {
         "exclude": [

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Markup assertions for PHPUnit.
  *

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -268,7 +268,8 @@ class MarkupAssertionsTraitTest extends TestCase
      * @testdox getInnerHtmlOfMatchedElements() should retrieve the inner HTML
      * @dataProvider provideInnerHtml
      */
-    public function getInnerHtmlOfMatchedElements_should_retrieve_the_inner_HTML($markup, $selector, $expected) {
+    public function getInnerHtmlOfMatchedElements_should_retrieve_the_inner_HTML($markup, $selector, $expected)
+    {
         $method = new \ReflectionMethod($this, 'getInnerHtmlOfMatchedElements');
         $method->setAccessible(true);
 


### PR DESCRIPTION
This PR introduces PHP_CodeSniffer with the PHPCompatibility ruleset, used to verify that everything aligns to PSR-12 and is compatible with our minimum PHP version (currently 5.6).