### PR TITLE
Use squizlabs, not phpcsstandards/php_codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpcsstandards/php_codesniffer": "^3.7",
+        "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^5.2 || ^6.2"
     },
     "autoload": {


### PR DESCRIPTION
After I had merged #45, @jrfnl (maintainer of PHP_CodeSniffer) [was kind enough to reach out and let me know that arrangements have been made to keep the original package name](https://github.com/stevegrunwell/phpunit-markup-assertions/pull/45#discussion_r1418174539). As such, this PR changes the dependency from phpcsstandards/php_codesniffer to squizlabs/php_codesniffer.