### PR TITLE
Install Phan for static code analysis

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,0 +1,23 @@
+name: Static Code Analysis
+
+on: [pull_request]
+
+jobs:
+  phpcs:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run PHPStan
+        run: composer static-analysis

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,9 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: none
 
+      - name: Remove PHPStan as a dependency
+        run: composer remove --dev phpstan/phpstan
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.DS_Store
 .phpunit.result.cache
 .vscode
+phpcs.xml
+phpstan.neon
+phpunit.xml
 tests/coverage
 vendor
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
+        "phpstan/phpstan": "^1.10",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^5.2 || ^6.2"
     },
@@ -39,6 +40,9 @@
         "coding-standards": [
             "phpcs"
         ],
+        "static-analysis": [
+            "phpstan analyse"
+        ],
         "test": [
             "simple-phpunit --testdox"
         ],
@@ -48,6 +52,7 @@
     },
     "scripts-descriptions": {
         "coding-standards": "Check coding standards.",
+        "static-analysis": "Run static code analysis",
         "test": "Run all test suites.",
         "test-coverage": "Generate code coverage reports in tests/coverage."
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+	level: 6
+	paths:
+		- src
+		- tests
+	excludePaths:
+		- tests/coverage


### PR DESCRIPTION
I'm apparently on a code quality kick (when am I not?), so this PR adds [PHPStan](https://phpstan.org/) for static code analysis.

It also sets up a GitHub Actions workflow for static code analysis, but I'm not going to worry about fixing the current issues as there's a major rewrite in #46.