### PR TITLE
Permit the 7.x branches of symfony/css-selector, symfony/dom-crawler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "symfony/css-selector": "^4.4|^5.4|^6.0",
-        "symfony/dom-crawler": "^4.4|^5.4|^6.0"
+        "symfony/css-selector": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/dom-crawler": "^4.4|^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",


### PR DESCRIPTION
If folks are using versions of PHP new enough to support them, by all means!