### PR TITLE
Update to PHPStan 2.x (and reach level 10)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -18,7 +18,7 @@
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
-    <!-- Ensure we're compatible with PHP 5.6+ -->
+    <!-- Ensure we're compatible with PHP 7.1+ -->
     <rule ref="PHPCompatibility"/>
     <config name="testVersion" value="7.1-"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^5.2 || ^6.2 || ^7.0"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,15 @@
 parameters:
 	level: 6
+
+	# Code to be analyzed
 	paths:
 		- src
 		- tests
+
+	# Don't worry about the coverage reports
 	excludePaths:
 		- tests/coverage
+
+	# PHPUnit Bridge puts the PHPUnit source in an unconventional location
+	scanDirectories:
+		- vendor/bin/.phpunit/phpunit

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,7 +8,7 @@ parameters:
 
 	# Don't worry about the coverage reports
 	excludePaths:
-		- tests/coverage
+		- tests/coverage (?)
 
 	# PHPUnit Bridge puts the PHPUnit source in an unconventional location
 	scanDirectories:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-	level: 6
+	level: 10
 
 	# Code to be analyzed
 	paths:

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -246,7 +246,7 @@ trait MarkupAssertionsTrait
             if (empty($value)) {
                 $value = sprintf('[%s]', $key);
             } else {
-                $value = sprintf('[%s="%s"]', $key, htmlspecialchars($value));
+                $value = sprintf('[%s="%s"]', $key, htmlspecialchars((string) $value));
             }
         });
 
@@ -270,10 +270,14 @@ trait MarkupAssertionsTrait
 
         // Loop through results and collect their innerHTML values.
         foreach ($results as $result) {
+            if (!isset($result->firstChild)) {
+                continue;
+            }
+
             $document = new \DOMDocument();
             $document->appendChild($document->importNode($result->firstChild, true));
 
-            $contents[] = trim(html_entity_decode($document->saveHTML()));
+            $contents[] = trim(html_entity_decode((string) $document->saveHTML()));
         }
 
         return implode(PHP_EOL, $contents);

--- a/src/MarkupAssertionsTrait.php
+++ b/src/MarkupAssertionsTrait.php
@@ -127,11 +127,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementContains($contents, $selector = '', $markup = '', $message = '')
     {
-        $method = method_exists($this, 'assertStringContainsString')
-            ? 'assertStringContainsString'
-            : 'assertContains'; // @codeCoverageIgnore
-
-        $this->$method(
+        $this->assertStringContainsString(
             $contents,
             $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
@@ -152,11 +148,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotContains($contents, $selector = '', $markup = '', $message = '')
     {
-        $method = method_exists($this, 'assertStringNotContainsString')
-            ? 'assertStringNotContainsString'
-            : 'assertNotContains'; // @codeCoverageIgnore
-
-        $this->$method(
+        $this->assertStringNotContainsString(
             $contents,
             $this->getInnerHtmlOfMatchedElements($markup, $selector),
             $message
@@ -177,6 +169,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementRegExp($regexp, $selector = '', $markup = '', $message = '')
     {
+        // @phpstan-ignore function.alreadyNarrowedType (Introduced in PHPUnit 9.x, PHP 7.3+)
         $method = method_exists($this, 'assertMatchesRegularExpression')
             ? 'assertMatchesRegularExpression'
             : 'assertRegExp'; // @codeCoverageIgnore
@@ -202,6 +195,7 @@ trait MarkupAssertionsTrait
      */
     public function assertElementNotRegExp($regexp, $selector = '', $markup = '', $message = '')
     {
+        // @phpstan-ignore function.alreadyNarrowedType (Introduced in PHPUnit 9.x, PHP 7.3+)
         $method = method_exists($this, 'assertDoesNotMatchRegularExpression')
             ? 'assertDoesNotMatchRegularExpression'
             : 'assertNotRegExp'; // @codeCoverageIgnore

--- a/tests/MarkupAssertionsTraitTest.php
+++ b/tests/MarkupAssertionsTraitTest.php
@@ -285,7 +285,7 @@ class MarkupAssertionsTraitTest extends TestCase
     /**
      * Data provider for testFlattenAttributeArray().
      *
-     * @return array<string,array{array<string,string>,string}>
+     * @return array<string,array{array<string,?string>,string}>
      */
     public function provideAttributes(): array
     {


### PR DESCRIPTION
This PR updates our PHPStan dependency to 2.x, cleans up its config file, then adds a few explicit type coercions in order to satisfy level 10.

As a bonus, since #52 dropped PHP < 7.1, we no longer need to account for PHPUnit 6.x (which didn't include `assertStringContainsString()`).