### PR TITLE
Rename the individual Composer scripts, update docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,11 +9,11 @@ Begin by cloning the GitHub repo locally and installing the dependencies with [C
 
 ```sh
 # Clone the repository + change into the directory
-$ git clone https://github.com/stevegrunwell/phpunit-markup-assertions.git \
-    && cd phpunit-markup-assertions
+git clone https://github.com/stevegrunwell/phpunit-markup-assertions.git \
+    && cd phpunit-markup-assertions;
 
 # Install local dependencies
-$ composer install
+composer install
 ```
 
 
@@ -23,12 +23,12 @@ Pull requests should be based off the `develop` branch, which represents the cur
 
 To create a new feature branch:
 
-```bash
+```sh
 # Start on develop, making sure it's up-to-date
-$ git checkout develop && git pull
+git checkout develop && git pull;
 
 # Create a new branch for your feature
-$ git checkout -b feature/my-cool-new-feature
+git checkout -b feature/my-cool-new-feature
 ```
 
 When submitting a new pull request, your `feature/my-cool-new-feature` should be compared against `develop`.
@@ -38,13 +38,19 @@ When submitting a new pull request, your `feature/my-cool-new-feature` should be
 
 This project uses [the PSR-2 coding standards](http://www.php-fig.org/psr/psr-2/).
 
+Standards are enforced via [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/), which can be run any time with the following:
+
+```sh
+composer test:standards
+```
+
 
 ### Running unit tests
 
 [PHPUnit](https://phpunit.de/) is included as a development dependency, and should be run regularly. When submitting changes, please be sure to add or update unit tests accordingly. You may run unit tests at any time by running:
 
-```bash
-$ composer test
+```sh
+composer test:unit
 ```
 
 #### Code coverage
@@ -53,8 +59,8 @@ $ composer test
 
 To generate a report of code coverage for the current branch, you may run the following Composer script, which will generate an HTML report in `tests/coverage/`:
 
-```bash
-$ composer test-coverage
+```sh
+composer test:coverage
 ```
 
 Note that [both the Xdebug and tokenizer PHP extensions must be installed and active](https://phpunit.de/manual/current/en/textui.html) on the machine running the tests.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -20,4 +20,4 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Run test suite
-        run: composer coding-standards
+        run: composer test:standards

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -25,4 +25,4 @@ jobs:
         run: composer test -- --version
 
       - name: Run PHPStan
-        run: composer static-analysis
+        run: composer test:analysis

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,4 +26,4 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Run test suite
-        run: composer test
+        run: composer test:unit

--- a/composer.json
+++ b/composer.json
@@ -37,24 +37,33 @@
         }
     },
     "scripts": {
-        "coding-standards": [
-            "phpcs"
+        "test": [
+            "@test:all"
         ],
-        "static-analysis": [
+        "test:all": [
+            "@test:unit",
+            "@test:standards",
+            "@test:analysis"
+        ],
+        "test:analysis": [
             "phpstan analyse"
         ],
-        "test": [
-            "simple-phpunit --testdox"
-        ],
-        "test-coverage": [
+        "test:coverage": [
             "XDEBUG_MODE=coverage ./vendor/bin/simple-phpunit --coverage-html=tests/coverage --colors=always"
+        ],
+        "test:standards": [
+            "phpcs"
+        ],
+        "test:unit": [
+            "simple-phpunit --testdox"
         ]
     },
     "scripts-descriptions": {
-        "coding-standards": "Check coding standards.",
-        "static-analysis": "Run static code analysis",
-        "test": "Run all test suites.",
-        "test-coverage": "Generate code coverage reports in tests/coverage."
+        "test:all": "Run all automated tests",
+        "test:analysis": "Run static code analysis",
+        "test:coverage": "Generate code coverage reports in tests/coverage.",
+        "test:standards": "Check coding standards.",
+        "test:unit": "Run all test suites."
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
Instead of `composer test` for PHPUnit, `composer static-analysis` for PHPStan, etc. group them all under the "test" namespace.

* `test:unit`: PHPUnit
* `test:analysis`: PHPStan
* `test:standards`: PHP_CodeSniffer
* `test:coverage`: Generate code coverage report
* `test:all`: Run everything but coverage
* `test`: alias for `test:all`